### PR TITLE
scikit-build-core v0.6.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
-    - https://staging.continuum.io/prefect/fs/pytest-subprocess-feedstock/pr1
-    - https://staging.continuum.io/prefect/fs/cattrs-feedstock/pr5
+    - https://staging.continuum.io/prefect/fs/pytest-subprocess-feedstock/pr1/8e6708d
+    - https://staging.continuum.io/prefect/fs/cattrs-feedstock/pr5/e3428c0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+    - https://staging.continuum.io/prefect/fs/pytest-subprocess-feedstock/pr1
+    - https://staging.continuum.io/prefect/fs/cattrs-feedstock/pr5

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-    - https://staging.continuum.io/prefect/fs/pytest-subprocess-feedstock/pr1/8e6708d
-    - https://staging.continuum.io/prefect/fs/cattrs-feedstock/pr5/e3428c0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,4 @@
-python -m pip install . -vv
+python -m pip install . --no-deps --no-build-isolation -vv
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,9 +2,9 @@ python -m pip install . --no-deps --no-build-isolation -vv
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d
-mkdir %ACTIVATE_DIR%
+if not exist "%ACTIVATE_DIR%" mkdir %ACTIVATE_DIR%
 if errorlevel 1 exit 1
-mkdir %DEACTIVATE_DIR%
+if not exist "%DEACTIVATE_DIR%" mkdir %DEACTIVATE_DIR%
 if errorlevel 1 exit 1
 
 copy %RECIPE_DIR%\scripts\activate.bat %ACTIVATE_DIR%\%PROJECT_NAME%-activate.bat

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,4 @@
-python -m pip install . -vv
+python -m pip install . --no-deps --no-build-isolation -vv
 
 # Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
 # This will allow them to be run on environment activation.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - exceptiongroup             # [py<311]
-    - importlib_metadata         # [py<38]
+    - importlib-metadata         # [py<38]
     - importlib_resources >=1.3  # [py<39]
     - packaging >=20.9
     - tomli >=1.1                # [py<311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
     # see thread https://github.com/scikit-build/scikit-build-core/issues/368
-    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
+    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
   source_files:
     - tests/
     - src/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
     # see thread https://github.com/scikit-build/scikit-build-core/issues/368
-    - pytest -vv -ra --showlocals -m "not (isolated or network)" -k "not (sdist_time_hash_set_epoch or sdist_hash)"
+    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
   source_files:
     - tests/
     - src/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-build-core" %}
-{% set version = "0.6.0" %}
+{% set version = "0.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/scikit_build_core-{{ version }}.tar.gz
-  sha256: 1bea5ed83610b367f3446badd996f2356690548188d6d38e5b93152df311a7ae
+  sha256: 392254a4ca7235c27a4be98cc24cd708f563171961ce37cff66120ebfda20b7a
 
 build:
   number: 0
@@ -25,18 +25,19 @@ requirements:
     - importlib_metadata         # [py<38]
     - importlib_resources >=1.3  # [py<39]
     - packaging >=20.9
-    - pyproject-metadata >=0.5
     - tomli >=1.1                # [py<311]
     - typing-extensions >=3.10   # [py<38]
   run_constrained:
     - pathspec >=0.10.1
+    - pyproject-metadata >=0.5
 
 test:
   imports:
     - scikit_build_core
   commands:
     - pip check
-    - pytest -vv -m "not isolated" -k "not sdist_time_hash_set_epoch and not sdist_hash"
+    # see thread https://github.com/scikit-build/scikit-build-core/issues/368
+    - pytest -vv -ra --showlocals -m "not (isolated or network)" -k "not (sdist_time_hash_set_epoch or sdist_hash)"
   source_files:
     - tests/
     - src/
@@ -51,10 +52,13 @@ test:
     - hatchling
     - make
     - ninja
+    - numpy
     - pip
+    - pathspec >=0.10.1
     - pybind11
+    - pyproject-metadata >=0.5
     - pytest >=7.0
-    - pytest-subprocess
+    - pytest-subprocess >=1.5
     - rich
     - setuptools
     - virtualenv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
     # see thread https://github.com/scikit-build/scikit-build-core/issues/368
-    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
+    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_pyproject_abi3.py::test_abi3_wheel --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
   source_files:
     - tests/
     - src/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,25 +10,26 @@ source:
   sha256: 1bea5ed83610b367f3446badd996f2356690548188d6d38e5b93152df311a7ae
 
 build:
-  noarch: python
   number: 0
+  skip: true  # [py<37]
 
 requirements:
   host:
     - hatch-vcs
     - hatchling
     - pip
-    - python >=3.7
+    - python
   run:
-    - python >=3.7
-    - exceptiongroup
-    - importlib-metadata
-    - importlib-resources >=1.3
+    - python
+    - exceptiongroup             # [py<311]
+    - importlib_metadata         # [py<38]
+    - importlib_resources >=1.3  # [py<39]
     - packaging >=20.9
-    - pathspec >=0.10.1
     - pyproject-metadata >=0.5
-    - tomli >=1.1
-    - typing-extensions >=3.10
+    - tomli >=1.1                # [py<311]
+    - typing-extensions >=3.10   # [py<38]
+  run_constrained:
+    - pathspec >=0.10.1
 
 test:
   imports:
@@ -60,12 +61,19 @@ test:
     - wheel
 
 about:
-  home: https://pypi.org/project/scikit-build-core/
+  home: https://github.com/scikit-build/scikit-build-core
   summary: Build backend for CMake based projects
+  description: |
+    Scikit-build-core is a ground-up rewrite of the classic Scikit-build, a bridge 
+    between Python package build systems and CMake, the most popular compiled language 
+    build system.
   license: Apache-2.0
+  license_family: Apache
   license_file:
     - LICENSE
     - src/scikit_build_core/resources/find_python/Copyright.txt
+  doc_url: https://scikit-build-core.readthedocs.io/
+  dev_url: https://github.com/scikit-build/scikit-build-core
 
 extra:
   recipe-maintainers:
@@ -73,3 +81,6 @@ extra:
     - henryiii
     - jcfr
     - thewtex
+  skip-lints:
+    # uses hatchling
+    - missing_wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
     # see thread https://github.com/scikit-build/scikit-build-core/issues/368
-    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg -k "not (sdist_time_hash_set_epoch or sdist_hash or test_pep517_wheel or test_abi3_wheel)"
+    - pytest -vv -ra --showlocals -m "not (isolated or network or virtualenv)" --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg -k "not (sdist_time_hash_set_epoch or sdist_hash)"
   source_files:
     - tests/
     - src/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
     # see thread https://github.com/scikit-build/scikit-build-core/issues/368
-    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_pyproject_pep517.py::test_pep517_wheel --deselect=tests/test_pyproject_abi3.py::test_abi3_wheel --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
+    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_setuptools_abi3.py::test_abi3_wheel --deselect=tests/test_pyproject_pep517.py::test_pep517_wheel --deselect=tests/test_pyproject_abi3.py::test_abi3_wheel --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
   source_files:
     - tests/
     - src/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,13 +31,21 @@ requirements:
     - pathspec >=0.10.1
     - pyproject-metadata >=0.5
 
+{% set tests_to_deselect = "" %}
+{% set tests_to_deselect = tests_to_deselect + "--deselect=tests/test_editable_unit.py::test_navigate_editable_pkg" %}
+# deselect these tests on win with symlink privileges OSError: [WinError 1314]
+{% set tests_to_deselect = tests_to_deselect + " --deselect=tests/test_file_processor.py::test_on_each_with_symlink" %}           # [win]
+# deselect these tests on win while build_wheel and build_editable
+{% set tests_to_deselect = tests_to_deselect + " --deselect=tests/test_pyproject_extra_dirs.py::test_pep517_wheel_extra_dirs" %}  # [win]
+{% set tests_to_deselect = tests_to_deselect + " --deselect=tests/test_pyproject_pep660.py::test_pep660_wheel" %}                 # [win]
+
 test:
   imports:
     - scikit_build_core
   commands:
     - pip check
     # see thread https://github.com/scikit-build/scikit-build-core/issues/368
-    - pytest -vv -ra --showlocals -m "not (isolated or network or virtualenv or setuptools or broken_on_urct)" --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg -k "not (sdist_time_hash_set_epoch or sdist_hash)"
+    - pytest -vv -ra --showlocals -m "not (isolated or network or virtualenv or setuptools or broken_on_urct)" {{tests_to_deselect}} -k "not (sdist_time_hash_set_epoch or sdist_hash)"
   source_files:
     - tests/
     - src/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
     # see thread https://github.com/scikit-build/scikit-build-core/issues/368
-    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_setuptools_abi3.py::test_abi3_wheel --deselect=tests/test_pyproject_pep517.py::test_pep517_wheel --deselect=tests/test_pyproject_abi3.py::test_abi3_wheel --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
+    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg -k "not (sdist_time_hash_set_epoch or sdist_hash or test_pep517_wheel or test_abi3_wheel)"
   source_files:
     - tests/
     - src/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     - cmake
     - hatch-vcs
     - hatchling
-    - make
+    - make  # [unix]
     - ninja
     - numpy
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
     # see thread https://github.com/scikit-build/scikit-build-core/issues/368
-    - pytest -vv -ra --showlocals -m "not (isolated or network or virtualenv)" --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg -k "not (sdist_time_hash_set_epoch or sdist_hash)"
+    - pytest -vv -ra --showlocals -m "not (isolated or network or virtualenv or setuptools or broken_on_urct)" --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg -k "not (sdist_time_hash_set_epoch or sdist_hash)"
   source_files:
     - tests/
     - src/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
     # see thread https://github.com/scikit-build/scikit-build-core/issues/368
-    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_pyproject_abi3.py::test_abi3_wheel --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
+    - pytest -vv -ra --showlocals -m "not (isolated or network)" --deselect=tests/test_pyproject_pep517.py::test_pep517_wheel --deselect=tests/test_pyproject_abi3.py::test_abi3_wheel --deselect=tests/test_editable_unit.py::test_navigate_editable_pkg --deselect=tests/test_dynamic_metadata.py::test_pep517_wheel -k "not (sdist_time_hash_set_epoch or sdist_hash)"
   source_files:
     - tests/
     - src/


### PR DESCRIPTION
[PKG-3297] scikit-build-core v0.6.1

- upstream: https://github.com/scikit-build/scikit-build-core/tree/v0.6.1
- dependency files:
    - https://github.com/scikit-build/scikit-build-core/blob/v0.6.1/pyproject.toml#L35-L42
- conda-forge: https://github.com/conda-forge/scikit-build-core-feedstock
- pypi: https://pypi.org/project/scikit-build-core/
    
**Destination channel:** `defaults`

**Changes**
- fix recipe
- update to `0.6.1`
- remove `no-arch`
- skip lints: `missing_wheel`
- skip some tests, see comments, but mostly everything to do with subprocess / Popen

**Depends on:**
- Tests:
    - AnacondaRecipes/cattrs-feedstock#5)
    - AnacondaRecipes/pytest-subprocess-feedstock#1

**Dependency for:**
- AnacondaRecipes/lightgbm-feedstock#7

[PKG-3297]: https://anaconda.atlassian.net/browse/PKG-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ