### PR TITLE
[PKG-3381] scikit-build-core v0.6.1 fix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 392254a4ca7235c27a4be98cc24cd708f563171961ce37cff66120ebfda20b7a
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,9 @@ requirements:
     - packaging >=20.9
     - tomli >=1.1                # [py<311]
     - typing-extensions >=3.10   # [py<38]
-  run_constrained:
+    # pathspec and pyproject-metadata are actually required because
+    # injected at runtime:
+    # https://github.com/scikit-build/scikit-build-core/blob/d7ba004/src/scikit_build_core/build/__init__.py#L113
     - pathspec >=0.10.1
     - pyproject-metadata >=0.5
 


### PR DESCRIPTION
[PKG-3381] scikit-build-core v0.6.1 fix

- upstream: https://github.com/scikit-build/scikit-build-core/tree/v0.6.1
- dependency files:
    - https://github.com/scikit-build/scikit-build-core/blob/v0.6.1/pyproject.toml#L35-L42
- conda-forge: https://github.com/conda-forge/scikit-build-core-feedstock
- pypi: https://pypi.org/project/scikit-build-core/
    
**Destination channel:** `defaults`

**Changes**
- `pathspec` and `pyproject-metadata` are actually required, add them in `run`
- build number to `1`

**Dependency for:**
- AnacondaRecipes/lightgbm-feedstock#7

[PKG-3297]: https://anaconda.atlassian.net/browse/PKG-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-3381]: https://anaconda.atlassian.net/browse/PKG-3381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ